### PR TITLE
Set From, To and Date header fields as swaks variable

### DIFF
--- a/_layouts/mailing.html
+++ b/_layouts/mailing.html
@@ -1,10 +1,11 @@
 ---
 ---
 Content-Language: en-US
-From: Eduard Itrich <itrich@osb-alliance.com>
+From: %FROM_ADDRESS%
 Organization: Open Source Business Alliance e.V.
-To: SCS Members List <scs-member@lists.scs.community>
+To: %TO_ADDRESS%
 Subject: SCS Community Digest #{{page.issue}}
+Date: %DATE%
 MIME-Version: 1.0
 Content-Type: multipart/alternative; boundary="{{page.multipart_boundary}}"
 Content-Class: urn:content-classes:message


### PR DESCRIPTION
This PR fixes #33 and sets the header fields From, To and Date as a swaks variable. See https://www.jetmore.org/john/code/swaks/latest/doc/ref.txt for more details.

Signed-off-by: Eduard Itrich <eduard@itrich.net>